### PR TITLE
Update to support L4T Deepstream 6.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ Run with default input video, writing output to `data-default`:
 
 `./docker/run.sh`
 
+After running, the file from data-default/output.mp4 will contain
+annotations from the OSD module including detected people and
+a count of people who have crossed line annotations.
+
 Run with custom input video at `/tmp/my-test-video.mp4`
 writing output to `data-default`:
 

--- a/docker/Dockerfile.Jetson
+++ b/docker/Dockerfile.Jetson
@@ -1,16 +1,13 @@
 ARG container_build_path=/opt/nvidia/deepstream/deepstream-6.0/sources/apps/sample_apps/deepstream-nvdsanalytics-docker 
-FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-base AS deepstream-deploy
-ARG container_build_path
-RUN apt-get update && apt-get install -y unzip
-
-FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-samples AS deepstream-build
+FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-samples
 ARG container_build_path
 
 RUN apt-get update && apt-get install -y build-essential \
 		libgstreamer1.0-dev \
 		libgstrtspserver-1.0-dev \
 		libjson-glib-dev \
-		wget
+		wget \
+                unzip
 
 RUN echo $container_build_path
 COPY . $container_build_path
@@ -19,23 +16,8 @@ WORKDIR $container_build_path
 
 RUN export CUDA_VER=10.2 && make -f Makefile.ds
 
-RUN ls -la $container_build_path
-RUN echo $container_build_path
-
-FROM deepstream-deploy
-ARG container_build_path
-
-RUN mkdir -p /usr/src/app/ && \
-    mkdir -p /usr/src/app/lib/
-
-COPY --from=deepstream-build $container_build_path/*.sh /usr/src/app/
-COPY --from=deepstream-build $container_build_path/deepstream-app /usr/src/app/
-
-# Not needed in production containers
-COPY --from=deepstream-build $container_build_path/cfg-deepstream-default \
-    /usr/src/app/cfg-deepstream-default
-COPY --from=deepstream-build $container_build_path/cfg-model-default \
-    /usr/src/app/cfg-model-default
+RUN mkdir -p /usr/src/ && \
+    ln -s $container_build_path /usr/src/app
 
 WORKDIR /usr/src/app
 

--- a/docker/Dockerfile.Jetson
+++ b/docker/Dockerfile.Jetson
@@ -1,46 +1,41 @@
-FROM nvcr.io/nvidia/deepstream-l4t:5.0.1-20.09-base AS deepstream-deploy
-FROM nvcr.io/nvidia/deepstream-l4t:5.0.1-20.09-samples AS deepstream-build
- 
-RUN apt-get update && apt-get install -y build-essential
-RUN apt-get install -y libgstreamer1.0-dev libgstrtspserver-1.0-dev
-RUN apt-get install -y libjson-glib-dev
-# Additional dependencies for building uff files within the container
-# We won't need these in production
-RUN apt-get install -y wget
+ARG container_build_path=/opt/nvidia/deepstream/deepstream-6.0/sources/apps/sample_apps/deepstream-nvdsanalytics-docker 
+FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-base AS deepstream-deploy
+ARG container_build_path
+RUN apt-get update && apt-get install -y unzip
 
-RUN mkdir -p /usr/src/app/src
+FROM nvcr.io/nvidia/deepstream-l4t:6.0.1-samples AS deepstream-build
+ARG container_build_path
 
-COPY . /usr/src/app/src
+RUN apt-get update && apt-get install -y build-essential \
+		libgstreamer1.0-dev \
+		libgstrtspserver-1.0-dev \
+		libjson-glib-dev \
+		wget
 
-WORKDIR /usr/src/app/src
+RUN echo $container_build_path
+COPY . $container_build_path
 
-RUN make -f Makefile.ds
+WORKDIR $container_build_path
+
+RUN export CUDA_VER=10.2 && make -f Makefile.ds
+
+RUN ls -la $container_build_path
+RUN echo $container_build_path
 
 FROM deepstream-deploy
-# Not needed in production container, only here for test purposes
-COPY --from=deepstream-build /opt/nvidia/deepstream/deepstream/samples/streams/sample_1080p_h265.mp4 \
-	/opt/nvidia/deepstream/deepstream/samples/streams/sample_1080p_h265.mp4
-# This is the only way I've found to get the tensorrt source dir copied into
-# the runtime container, for dynamic conversion from .pb to .uff.  It could
-# be simplified and could be removed for production images if we don't need
-# to support conversion from .pb to .uff
-COPY --from=deepstream-build /usr/src/ \
-    /usr/src/
+ARG container_build_path
 
 RUN mkdir -p /usr/src/app/ && \
     mkdir -p /usr/src/app/lib/
 
-RUN apt-get install -y unzip
-
-COPY --from=deepstream-build /usr/src/app/src/*.sh /usr/src/app/
-COPY --from=deepstream-build /usr/src/app/src/deepstream-app /usr/src/app/
+COPY --from=deepstream-build $container_build_path/*.sh /usr/src/app/
+COPY --from=deepstream-build $container_build_path/deepstream-app /usr/src/app/
 
 # Not needed in production containers
-COPY --from=deepstream-build /usr/src/app/src/cfg-deepstream-default \
+COPY --from=deepstream-build $container_build_path/cfg-deepstream-default \
     /usr/src/app/cfg-deepstream-default
-COPY --from=deepstream-build /usr/src/app/src/cfg-model-default \
+COPY --from=deepstream-build $container_build_path/cfg-model-default \
     /usr/src/app/cfg-model-default
-
 
 WORKDIR /usr/src/app
 

--- a/docker/Dockerfile.dGPU
+++ b/docker/Dockerfile.dGPU
@@ -1,4 +1,4 @@
-FROM nvcr.io/nvidia/deepstream:5.0.1-20.09-base AS deepstream-deploy
+FROM nvcr.io/nvidia/deepstream:6.0.1-base AS deepstream-deploy
 # None of the dGPU containers include the tensorrt/samples directory and
 # the corresponding nvinfer package also doesn't exist.  So pull this file
 # out of the github archive instead.
@@ -10,14 +10,11 @@ RUN mkdir -p /usr/src/app/src
 # A sample file so we can run without setup if needed.  Also not needed
 # for production
 RUN mkdir -p /opt/nvidia/deepstream/deepstream/samples/streams
-COPY --from=nvcr.io/nvidia/deepstream:5.0.1-20.09-samples \ 
+COPY --from=nvcr.io/nvidia/deepstream:6.0.1-devel \ 
     /opt/nvidia/deepstream/deepstream/samples/streams/sample_1080p_h265.mp4 \
     /opt/nvidia/deepstream/deepstream/samples/streams
 
-# With the samples container I hit the bug at
-# https://forums.developer.nvidia.com/t/nvcaffeparser-h-missing-in-docker-for-deepstream-5-0-objectdetector-yolo/154623/5?u=danwalkes1
-# attmpting to build the nvdsinfer plugin.
-FROM nvcr.io/nvidia/deepstream:5.0.1-20.09-triton AS deepstream-build
+FROM nvcr.io/nvidia/deepstream:6.0.1-devel AS deepstream-build
  
 RUN apt-get update && apt-get install -y build-essential
 RUN apt-get install -y libgstreamer1.0-dev libgstrtspserver-1.0-dev
@@ -29,7 +26,7 @@ COPY . /usr/src/app/src
 
 WORKDIR /usr/src/app/src
 
-RUN make -f Makefile.ds
+RUN export CUDA_VER=10.2 && make -f Makefile.ds
 
 FROM deepstream-deploy
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,4 +6,4 @@ uname -m | grep aarch64 > /dev/null
 if [ $? -eq 0 ]; then
     dockerfile=docker/Dockerfile.Jetson
 fi
-docker build -t bai-deepstream -f ${dockerfile} src
+docker build -t deepstream-nvdsanalytics-docker -f ${dockerfile} src

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -8,11 +8,11 @@ if [ $? -ne 0 ]; then
     echo "To override location for persistent data dir, pass a volume mount as"
     echo "argument to this script, for instance with "
     echo "  \"-v /path/to/datadir:/data\""
+    mkdir -p data-default
     datamount="-v $(realpath data-default):/data"
 fi
 echo "Running docker with arguments ${datamount} $@"
 docker run --net=host --runtime nvidia \
-    -v ${data_dir}:/data/ \
     ${datamount} \
     $@ \
    -it deepstream-nvdsanalytics-docker

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -15,4 +15,4 @@ docker run --net=host --runtime nvidia \
     -v ${data_dir}:/data/ \
     ${datamount} \
     $@ \
-   -it bai-deepstream
+   -it deepstream-nvdsanalytics-docker

--- a/src/Makefile
+++ b/src/Makefile
@@ -20,11 +20,16 @@
 # DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+CUDA_VER?=
+ifeq ($(CUDA_VER),)
+  $(error "CUDA_VER is not set")
+endif
+
 APP:= deepstream-nvdsanalytics-test
 
 TARGET_DEVICE = $(shell gcc -dumpmachine | cut -f1 -d -)
 
-NVDS_VERSION:=5.0
+NVDS_VERSION:=6.0
 
 LIB_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
 APP_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/bin/
@@ -41,17 +46,16 @@ PKGS:= gstreamer-1.0
 
 OBJS:= $(SRCS:.cpp=.o)
 
-DEEPSTREAM_SOURCES=/opt/nvidia/deepstream/deepstream-5.0/sources
-DEEPSTREAM_SOURCES_APPS=$(DEEPSTREAM_SOURCES)/apps
+CFLAGS+= -I../../../includes \
+		 -I /usr/local/cuda-$(CUDA_VER)/include
 
-CFLAGS+= -I$(DEEPSTREAM_SOURCES)/includes
+CFLAGS+= $(shell pkg-config --cflags $(PKGS))
 
-CFLAGS+= `pkg-config --cflags $(PKGS)`
-
-LIBS:= `pkg-config --libs $(PKGS)`
+LIBS:= $(shell pkg-config --libs $(PKGS))
 
 LIBS+= -L$(LIB_INSTALL_DIR) -lnvdsgst_meta -lnvds_meta -lnvdsgst_helper -lm \
-       -Wl,-rpath,$(LIB_INSTALL_DIR)
+       	-L/usr/local/cuda-$(CUDA_VER)/lib64/ -lcudart \
+	   -lcuda -Wl,-rpath,$(LIB_INSTALL_DIR)
 
 all: $(APP)
 

--- a/src/Makefile.ds
+++ b/src/Makefile.ds
@@ -20,13 +20,18 @@
 # DEALINGS IN THE SOFTWARE.
 ################################################################################
 
+CUDA_VER?=
+ifeq ($(CUDA_VER),)
+  $(error "CUDA_VER is not set")
+endif
+
 APP:= deepstream-app
 
 CXX=g++
 
 TARGET_DEVICE = $(shell gcc -dumpmachine | cut -f1 -d -)
 
-NVDS_VERSION:=5.0
+NVDS_VERSION:=6.0
 
 LIB_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/lib/
 APP_INSTALL_DIR?=/opt/nvidia/deepstream/deepstream-$(NVDS_VERSION)/bin/
@@ -35,10 +40,8 @@ ifeq ($(TARGET_DEVICE),aarch64)
   CFLAGS:= -DPLATFORM_TEGRA
 endif
 
-DEEPSTREAM_SOURCES=/opt/nvidia/deepstream/deepstream-5.0/sources
-DEEPSTREAM_SOURCES_APPS=$(DEEPSTREAM_SOURCES)/apps
-SRCS:= $(wildcard $(DEEPSTREAM_SOURCES_APPS)/apps-common/src/*.c)
-SRCS+= $(wildcard $(DEEPSTREAM_SOURCES_APPS)/sample_apps/deepstream-app/deepstream_app.c $(DEEPSTREAM_SOURCES_APPS)/sample_apps/deepstream-app/deepstream_app_config_parser.c)
+SRCS:= $(wildcard ../../apps-common/src/*.c)
+SRCS+= $(wildcard ../deepstream-app/deepstream_app.c ../deepstream-app/deepstream_app_config_parser.c)
 
 INCS:= $(wildcard *.h)
 
@@ -47,14 +50,17 @@ PKGS:= gstreamer-1.0 gstreamer-video-1.0 x11 json-glib-1.0
 OBJS:= $(SRCS:.c=.o)
 OBJS+= deepstream_nvdsanalytics_meta.o deepstream_app_main.o
 
-CFLAGS+= -I./ -I$(DEEPSTREAM_SOURCES_APPS)/apps-common/includes -I$(DEEPSTREAM_SOURCES)/includes  -I$(DEEPSTREAM_SOURCES_APPS)/sample_apps/deepstream-app/ -DDS_VERSION_MINOR=0 -DDS_VERSION_MAJOR=5
+CFLAGS+= -I./ -I../../apps-common/includes -I../../../includes  -I../deepstream-app/ -DDS_VERSION_MINOR=0 -DDS_VERSION_MAJOR=5 \
+		 -I /usr/local/cuda-$(CUDA_VER)/include
 
 LIBS+= -L$(LIB_INSTALL_DIR) -lnvdsgst_meta -lnvds_meta -lnvdsgst_helper -lnvdsgst_smartrecord -lnvds_utils -lnvds_msgbroker -lm \
-       -lgstrtspserver-1.0 -ldl -Wl,-rpath,$(LIB_INSTALL_DIR)
+       -lgstrtspserver-1.0 -ldl -Wl,-rpath,$(LIB_INSTALL_DIR) \
+	   -L/usr/local/cuda-$(CUDA_VER)/lib64/ -lcudart \
+	   -lcuda 
 
-CFLAGS+= `pkg-config --cflags $(PKGS)`
+CFLAGS+= $(shell pkg-config --cflags $(PKGS))
 
-LIBS+= `pkg-config --libs $(PKGS)`
+LIBS+= $(shell pkg-config --libs $(PKGS))
 
 all: $(APP)
 

--- a/src/cfg-deepstream-default/bai_deepstream.txt
+++ b/src/cfg-deepstream-default/bai_deepstream.txt
@@ -102,9 +102,7 @@ nvbuf-memory-type=0
 enable=1
 tracker-width=640
 tracker-height=384
-#ll-lib-file=/opt/nvidia/deepstream/deepstream-5.0/lib/libnvds_mot_iou.so
-ll-lib-file=/opt/nvidia/deepstream/deepstream-5.0/lib/libnvds_nvdcf.so
-#ll-lib-file=/opt/nvidia/deepstream/deepstream-5.0/lib/libnvds_mot_klt.so
+ll-lib-file=/opt/nvidia/deepstream/deepstream/lib/libnvds_nvmultiobjecttracker.so
 #ll-config-file required for DCF/IOU only
 ll-config-file=tracker_config.yml
 #ll-config-file=iou_config.txt

--- a/src/initScript.sh
+++ b/src/initScript.sh
@@ -1,16 +1,21 @@
 #!/bin/bash
 cd $(dirname $0)
 if [ ! -d /data/cfg/deepstream ]; then
-	echo "deepstream config directory doesn't exist, creating from defaults"
-	mkdir -p /data/cfg/deepstream
+    echo "deepstream config directory doesn't exist, creating from defaults"
+    mkdir -p /data/cfg/deepstream
     chmod -R 777 /data
 fi
 cp --no-clobber -r cfg-deepstream-default/* /data/cfg/deepstream/
 mkdir -p /data/cfg/model
 mkdir -p /input
+
 if [ ! -e /input/video.mp4 ]; then
-    echo "No default video found at /input/video.mp4, using sample"
-    ln -s /opt/nvidia/deepstream/deepstream/samples/streams/sample_1080p_h265.mp4 /input/video.mp4
+    if [ ! -e /data/input/video.mp4 ]; then
+       echo "No default video found at /input/video.mp4, copying sample as input"
+       mkdir -p /data/input/
+       cp /opt/nvidia/deepstream/deepstream/samples/streams/sample_1080p_h265.mp4 /data/input/video.mp4
+    fi
+    ln -s /data/input/video.mp4 /input/video.mp4
 fi
 if [ ! -d /output ]; then
     echo "No dedicated output mount found, using /data/output dir"

--- a/src/setup-peoplenet.sh
+++ b/src/setup-peoplenet.sh
@@ -3,10 +3,10 @@ set -e
 tmpdir=`mktemp -d`
 if [ ! -f /data/cfg/model/*.etlt ]; then
     echo "No .etlt file found, setting up peoplenet"
-    wget --content-disposition https://api.ngc.nvidia.com/v2/models/nvidia/tlt_peoplenet/versions/pruned_v2.0/zip \
-        -O ${tmpdir}/tlt_peoplenet_pruned_v2.0.zip
+    wget --content-disposition https://api.ngc.nvidia.com/v2/models/nvidia/tao/peoplenet/versions/pruned_v2.0/zip \
+        -O ${tmpdir}/peoplenet_pruned_v2.0.zip
     pushd ${tmpdir}
-    unzip tlt_peoplenet_pruned_v2.0.zip
+    unzip peoplenet_pruned_v2.0.zip
     cp ${tmpdir}/resnet34_peoplenet_pruned.etlt /data/cfg/model/
     cp ${tmpdir}/labels.txt /data/cfg/model/
     popd


### PR DESCRIPTION
* Modify scripts and dockerfiles to support Deepstream 6.0.1
* Simplify dockerfile logic to remove multistage builds for clarity.
* dGPU builds are not yet working/completely updated.